### PR TITLE
mse: don't drop vaddr on way to driver

### DIFF
--- a/ravb_eavb.h
+++ b/ravb_eavb.h
@@ -8,6 +8,7 @@
 struct eavb_entryvec {
 	uint32_t base;
 	uint32_t len;
+	void *vaddr;
 };
 
 struct eavb_entry {


### PR DESCRIPTION
as it might be needed in streaming driver.
The 'standard' streaming driver (RCAR ravb_streaming) does not touch the
packet content and thus the DMA address is sufficient.
Other streaming drivers (e.g. the upcoming igb_streaming driver for intel
igb card) need to copy/modify packet content which makes it necessary
to also pass the virtual buffer address to the streaming driver.

Required by https://github.com/renesas-rcar/avb-mse/pull/1